### PR TITLE
Changed Cirrious.MvvmCross.Droid.FullFragging to use API 15

### DIFF
--- a/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Cirrious.MvvmCross.Droid.FullFragging.csproj
+++ b/Cirrious/Cirrious.MvvmCross.Droid.FullFragging/Cirrious.MvvmCross.Droid.FullFragging.csproj
@@ -15,7 +15,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk />
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0.3</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Project "Cirrious.MvvmCross.Droid.FullFragging" is built on Api Level 14 (4.0) which is marked as obsolete in SDK console.

This should be changed to API Level 15.
